### PR TITLE
Arena/Bot death updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+*.cache
+.vs/InfServer/v15/Server/sqlite3/db.lock
+.vs/InfServer/v15/Server/sqlite3/storage.ide
+.vs/InfServer/v15/Server/sqlite3/storage.ide-shm
+.vs/InfServer/v15/Server/sqlite3/storage.ide-wal
+.vs/InfServer/v15/.suo

--- a/Branches/Docs/Client/infoareacolors.txt
+++ b/Branches/Docs/Client/infoareacolors.txt
@@ -1,0 +1,12 @@
+triggerMessage/Infoarea color designations:
+
+(byte) 0 = White
+(byte) 1 = Red
+(byte) 2 = Green
+(byte) 3 = Blue
+(byte) 4 = Yellow
+(byte) 5 = Purple
+(byte) 6 = Aqua
+(byte) 7 = Gray
+
+The rest seem to be darker variants of the above colors up until 48 where it turns into black.

--- a/InfServer/Game/Arena/Arena.cs
+++ b/InfServer/Game/Arena/Arena.cs
@@ -23,6 +23,7 @@ namespace InfServer.Game
         public LogClient _logger;						//The logger we use for this arena!
         public volatile bool _bActive;					//Is the arena functioning, or condemned?
         public bool _bIsPublic;							//Is this a public arena?
+        public bool _bIsNamed;                          //Is this a named arena?
 
         public ZoneServer _server;						//The server we belong to
         public Bots.Pathfinder _pathfinder;				//The pathfinding object used for this arena

--- a/InfServer/Game/Arena/ArenaState.cs
+++ b/InfServer/Game/Arena/ArenaState.cs
@@ -166,10 +166,14 @@ namespace InfServer.Game
         /// Called when a new player is entering our arena
         /// </summary>
         public void newPlayer(Player player)
-        {	///////////////////////////////////////////////
+        {   ///////////////////////////////////////////////
             // Prepare the player state
-            ///////////////////////////////////////////////           
-            
+            ///////////////////////////////////////////////       
+
+            //First player entering a inactive named arena? Let's flip on the lights for him
+            if (_bIsNamed && !_bActive)
+                _bActive = true;
+
             //We're entering the arena..
             player._arena = this;
 
@@ -419,10 +423,14 @@ namespace InfServer.Game
                 }
             }
 
-            //Do we have any players left?
-            if (TotalPlayerCount == 0)
+            //Do we have any players left? Don't close named arenas (We always want these displayed so players know they exist)
+            if (TotalPlayerCount == 0 && !_bIsNamed)
+            {
                 //Nope. It's closing time.
                 close();
+                //Flag the arena as inactive so it's no longer polled
+                _bActive = false;
+            }
             else
             {
                 //Notify everyone else of his departure

--- a/InfServer/Game/ZoneArenas.cs
+++ b/InfServer/Game/ZoneArenas.cs
@@ -50,6 +50,18 @@ namespace InfServer.Game
         }
 
         /// <summary>
+        /// Handles the creation of all of our named arenas (These do -not- close when the player count hits zero)
+        /// </summary>
+        private void initNamedArenas()
+        {
+            IList<ConfigSetting> namedArenas = _config["arena"].GetNamedChildren("namedArena");
+            foreach (ConfigSetting named in namedArenas)
+            {
+                newArena(named.Name);
+            }
+        }
+
+        /// <summary>
         /// Looks after the gamestate of all arenas
         /// </summary>
         private void handleArenas()
@@ -115,12 +127,14 @@ namespace InfServer.Game
             //Is this a registered arena name?
             string invokerType = _config["server/gameType"].Value;
             IList<ConfigSetting> namedArenas = _config["arena"].GetNamedChildren("namedArena");
+            bool isNamed = false;
 
             foreach (ConfigSetting named in namedArenas)
             {	//Correct arena?
                 if (name.Equals(named.Value, StringComparison.OrdinalIgnoreCase))
                 {
                     invokerType = named["gameType"].Value;
+                    isNamed = true;
                     break;
                 }
             }
@@ -137,7 +151,7 @@ namespace InfServer.Game
 
             arena._bActive = true;
             arena._name = name;
-            if (arena._name.StartsWith("Public"))
+            if (arena._name.StartsWith("Public") || isNamed)
                 arena._bIsPublic = true;
             else
                 arena._bIsPublic = false;

--- a/InfServer/Logic/General/Rewards.cs
+++ b/InfServer/Logic/General/Rewards.cs
@@ -115,7 +115,7 @@ namespace InfServer.Logic
                     continue;
 
                 //Let em know
-                p.triggerMessage(5, 500,
+                p.triggerMessage(4, 500,
                     String.Format("{0} killed by {1} (Cash={2} Exp={3} Points={4})",
                     victim._type.Name, killer._alias, cashRewards[p._id],
                     expRewards[p._id], pointRewards[p._id]));
@@ -142,11 +142,15 @@ namespace InfServer.Logic
                 if (sentTo.Contains(p._id))
                     continue;
 
+                //Adjust our color accordingly..
+                byte color = 0;
+                if (victim._team == p._team)
+                    color = 4;
+
                 //Let them know
-                p.triggerMessage(1, 500,
-                    String.Format("{0} killed by {1} (Cash={2} Exp={3} Points={4})",
-                    victim._type.Name, killer._alias,
-                    killerCash, killerExp, killerPoints));
+                p.triggerMessage(color, 500,
+                    String.Format("{0} killed by {1}",
+                    victim._type.Name, killer._alias));
             }
         }
 		


### PR DESCRIPTION
Altered logic behind named arenas, they now stay open with 0 players (Will always show in ?arena)

Fixed bot death infoarea alerts to show correct colors depending on whether it was a team kill, personal kill, or other team kill.