### PR TITLE
Script Compiling Fixes

### DIFF
--- a/InfServer/Game/Arena/Arena.cs
+++ b/InfServer/Game/Arena/Arena.cs
@@ -484,6 +484,13 @@ namespace InfServer.Game
         }
 
         /// <summary>
+        /// Reloads our scripts
+        /// </summary>
+        public virtual void reloadScript()
+        {
+        }
+
+        /// <summary>
         /// Adds an event to be processed
         /// </summary>
         public void handleEvent(Action<Arena> action)

--- a/InfServer/Game/Commands/Sysop/Server.cs
+++ b/InfServer/Game/Commands/Sysop/Server.cs
@@ -9,14 +9,14 @@ using InfServer.Protocol;
 
 namespace InfServer.Game.Commands.Mod
 {
-	/// <summary>
-	/// Provides a series of functions for handling mod commands
-	/// </summary>
-	public class Server
-	{
-		/// <summary>
-		/// Restarts the server
-		/// </summary>
+    /// <summary>
+    /// Provides a series of functions for handling mod commands
+    /// </summary>
+    public class Server
+    {
+        /// <summary>
+        /// Restarts the server
+        /// </summary>
         static public void recycle(Player player, Player recipient, string payload, int bong)
         {
             //Power check
@@ -45,6 +45,29 @@ namespace InfServer.Game.Commands.Mod
         }
 
         /// <summary>
+        /// Recompiles any active scripts
+        /// </summary>
+        static public void reloadscripts(Player player, Player recipient, string payload, int bong)
+        {
+            //Power check
+            if (player._developer && player.PermissionLevelLocal < Data.PlayerPermission.SMod)
+            {
+                player.sendMessage(-1, "Only mods or level 3 dev's and higher can use this command.");
+                return;
+            }
+
+            //Tell him we're doing our best!
+            player.sendMessage(0, "Attempting to reload scripts...");
+
+            //Lets do some thangs
+            if (!player._server.reloadScripts())
+                player.sendMessage(-1, "Error reloading scripts, please check logs for more info");
+            //ruh roh
+            else
+                player.sendMessage(0, "Scripts have been reloaded successfully");
+        }
+
+        /// <summary>
         /// Grabs logs
         /// </summary>
         static public void log(Player player, Player recipient, string payload, int bong)
@@ -68,23 +91,23 @@ namespace InfServer.Game.Commands.Mod
             }
         }
 
-		/// <summary>
-		/// Queries environment information from a player
-		/// </summary>
+        /// <summary>
+        /// Queries environment information from a player
+        /// </summary>
         static public void environment(Player player, Player recipient, string payload, int bong)
-		{	//Send him an environment packet!
-			SC_Environment env = new SC_Environment();
+        {   //Send him an environment packet!
+            SC_Environment env = new SC_Environment();
             bool limit;
             if (String.IsNullOrEmpty(payload))
                 limit = false;
             else
                 limit = true;
 
-			env.bLimitLength = limit;
+            env.bLimitLength = limit;
 
-			recipient.setVar("envReq", player);
-			recipient._client.sendReliable(env);
-		}
+            recipient.setVar("envReq", player);
+            recipient._client.sendReliable(env);
+        }
 
         /// <summary>
         /// Hack check prototype
@@ -112,11 +135,11 @@ namespace InfServer.Game.Commands.Mod
             }
         }
 
-		/// <summary>
-		/// Just handy for testing packet functionality
-		/// </summary>
+        /// <summary>
+        /// Just handy for testing packet functionality
+        /// </summary>
         static public void testPacket(Player player, Player recipient, string payload, int bong)
-		{
+        {
             //recipient._client.destroy();
             /*
             Disconnect discon = new Disconnect();
@@ -133,7 +156,7 @@ namespace InfServer.Game.Commands.Mod
             test.ball = player._arena._balls.SingleOrDefault(b => b._id == (ushort)0);
             player._client.sendReliable(test);
              */
-            
+
             SC_TestPacket test = new SC_TestPacket();
             test.player = player;
             player._client.send(test);
@@ -145,26 +168,26 @@ namespace InfServer.Game.Commands.Mod
             reg.location = "HKEY_CURRENT_USER\\SOFTWARE\\7-Zip\\Path";
             player._client.sendReliable(reg);
              */
-		}
+        }
 
         /// <summary>
         /// Displays a gif
         /// </summary>
         static public void showGif(Player player, Player recipient, string payload, int bong)
-		{	//Download the gif!
-		/*	
-            WebClient client = new WebClient();
-			Stream file = client.OpenRead(payload);
-			BinaryReader br = new BinaryReader(file);
-			SC_ShowGif gif = new SC_ShowGif();
+        {   //Download the gif!
+            /*	
+                WebClient client = new WebClient();
+                Stream file = client.OpenRead(payload);
+                BinaryReader br = new BinaryReader(file);
+                SC_ShowGif gif = new SC_ShowGif();
 
-			gif.gifData = br.ReadBytes(1024 * 1024);
-			gif.displayTime = 50;
-			gif.website = payload;
+                gif.gifData = br.ReadBytes(1024 * 1024);
+                gif.displayTime = 50;
+                gif.website = payload;
 
-			recipient._client.sendReliable(gif, 1);
-         */    
-		}
+                recipient._client.sendReliable(gif, 1);
+             */
+        }
 
         /// <summary>
         /// Returns a list of mod commands used in every zone
@@ -200,7 +223,7 @@ namespace InfServer.Game.Commands.Mod
                         {
                             page = Convert.ToInt32(args[1]);
                         }
-                        catch 
+                        catch
                         {
                             page = 0; //Convert doesn't do negative numbers
                         }
@@ -257,12 +280,12 @@ namespace InfServer.Game.Commands.Mod
             }
         }
 
-		/// <summary>
-		/// Registers all handlers
-		/// </summary>
-		[Commands.RegistryFunc(HandlerType.ModCommand)]
-		static public IEnumerable<Commands.HandlerDescriptor> Register()
-		{
+        /// <summary>
+        /// Registers all handlers
+        /// </summary>
+        [Commands.RegistryFunc(HandlerType.ModCommand)]
+        static public IEnumerable<Commands.HandlerDescriptor> Register()
+        {
             yield return new HandlerDescriptor(admins, "admins",
                 "Currently returns a list of powered admins",
                 "*admins or *admins list",
@@ -293,6 +316,11 @@ namespace InfServer.Game.Commands.Mod
                 "*recycle",
                 InfServer.Data.PlayerPermission.Mod, true);
 
+            yield return new HandlerDescriptor(reloadscripts, "reloadscripts",
+                "Reloads the specified scripts for all arenas in the zoneserver",
+                "*reloadscripts",
+                InfServer.Data.PlayerPermission.Mod, true);
+
             yield return new HandlerDescriptor(showGif, "showgif",
                 "Sends a gif to the target player",
                 "::*showgif [gif url]",
@@ -304,10 +332,10 @@ namespace InfServer.Game.Commands.Mod
                 InfServer.Data.PlayerPermission.Sysop, false);
 
             yield return new HandlerDescriptor(testPacket, "testpacket",
-				"Sends a test packet to the target player or just sends a packet",
-				"::*testpacket, *testpacket",
-				InfServer.Data.PlayerPermission.Sysop, false);
+                "Sends a test packet to the target player or just sends a packet",
+                "::*testpacket, *testpacket",
+                InfServer.Data.PlayerPermission.Sysop, false);
 
-		}
-	}
+        }
+    }
 }

--- a/InfServer/Game/ZoneArenas.cs
+++ b/InfServer/Game/ZoneArenas.cs
@@ -135,15 +135,20 @@ namespace InfServer.Game
                     break;
                 }
             }
+            bool bScriptLoad = true;
             //Instance our gametype
             if (!Scripting.Scripts.invokerTypeExists(invokerType))
             {
                 Log.write(TLog.Error, "Unable to find gameType '{0}'", invokerType);
-                return null;
+                bScriptLoad = false;
             }
 
             //Populate the class
-            Arena arena = new ScriptArena(this, invokerType);
+            Arena arena;
+            if (bScriptLoad)
+                arena = new ScriptArena(this, invokerType);
+            else
+                arena = new ScriptArena(this, null);
 
             if (!isNamed)
                 arena._bActive = true;

--- a/InfServer/Game/ZoneServer.cs
+++ b/InfServer/Game/ZoneServer.cs
@@ -272,13 +272,11 @@ namespace InfServer.Game
                 if (!bSuccess)
                 {	//Failed. Exit
                     Log.write(TLog.Error, "Unable to load scripts.");
-                    return false;
                 }
             }
             catch (Exception ex)
             {	//Error while compiling
                 Log.write(TLog.Exception, "Exception while compiling scripts:\n" + ex.ToString());
-                return false;
             }
 
             if (_config["server/pathFindingEnabled"].boolValue)
@@ -347,6 +345,35 @@ namespace InfServer.Game
             //Create all of our namedArenas
             initNamedArenas();
             return true;
+        }
+
+        /// <summary>
+        /// Reloads all of our scripts
+        /// </summary>
+        public bool reloadScripts()
+        {
+            bool bSuccess = false;
+
+            try
+            {	//Loads!
+                bSuccess = Scripting.Scripts.compileScripts();
+                if (!bSuccess)
+                {	//Failed. Exit
+                    Log.write(TLog.Error, "Unable to load scripts.");
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {	//Error while compiling
+                Log.write(TLog.Exception, "Exception while compiling scripts:\n" + ex.ToString());
+                return false;
+            }
+
+            //If we've gotten this far, we've had success, lets tell each arena to reload its specified script
+            foreach (Arena arena in _arenas.Values)
+                arena.reloadScript();
+
+            return bSuccess;
         }
 
         /// <summary>


### PR DESCRIPTION
Zoneservers will now continue to load irregardless of script compiling errors.
Added *reloadscripts. This allows managers/developers to hot reload their scripts in the event of errors or needing to make a quick fix without disrupting gameplay entirely by recycling.