### PR TITLE
TeamChangeEnable/Wipecharacter Fixes

### DIFF
--- a/InfServer/Game/Commands/Chat/Commands.cs
+++ b/InfServer/Game/Commands/Chat/Commands.cs
@@ -1473,7 +1473,7 @@ namespace InfServer.Game.Commands.Chat
                 return;
 
             //Valid terrain?
-            if (player._arena.getTerrain(player._state.positionX, player._state.positionY).teamChangeEnabled && player.IsSpectator == false)
+            if (player._arena.getTerrain(player._state.positionX, player._state.positionY).teamChangeEnabled == false && player.IsSpectator == false)
             {
                 player.sendMessage(-1, "Can't change team from this terrain");
                 return;

--- a/InfServer/Game/Objects/Player.cs
+++ b/InfServer/Game/Objects/Player.cs
@@ -491,6 +491,11 @@ namespace InfServer.Game
 		/// </summary>
         public void setDefaultSkill()
         {
+            ///
+            ///Really not sure what the intent was with this. Infantry has always never given a default skill UNLESS addskill= was used.
+            ///
+
+            /*
 			//Find his natural vehicle id and prepare the class
 			SkillItem baseSkill = _skills.Values.FirstOrDefault(skill => skill.skill.DefaultVehicleId != -1);
             int baseVehicleID = (baseSkill == null) ? _server._zoneConfig.publicProfile.defaultVItemId : baseSkill.skill.DefaultVehicleId;
@@ -500,7 +505,7 @@ namespace InfServer.Game
                 SkillInfo skill = _server._assets.getSkillByName(_baseVehicle._type.Name);
                 if (skill != null)
                     skillModify(skill, 1);
-            }
+            }*/
         }
 
         /// <summary>


### PR DESCRIPTION
Corrected terrain-based team switching.

Commented out a poorly thought out method that would always automatically default a player to the skill he had before ?wipecharacter was used. Will return to this if there are any unwanted side-effects in any zones.