### PR TITLE
Fix initial hides

### DIFF
--- a/InfServer/Game/Arena/ArenaLio.cs
+++ b/InfServer/Game/Arena/ArenaLio.cs
@@ -670,7 +670,7 @@ namespace InfServer.Game
                 if (hs.Hide.HideData.MinPlayerDistance != 0 &&
                     getPlayersInRange(sp.posX, sp.posY, hs.Hide.HideData.MinPlayerDistance, true).Count > 0)
                     continue;
-                if (hs.Hide.HideData.MaxPlayerDistance < Int32.MaxValue &&
+                if (hs.Hide.HideData.MaxPlayerDistance < 99999 &&
                     getPlayersInRange(sp.posX, sp.posY, hs.Hide.HideData.MaxPlayerDistance, true).Count == 0)
                     continue;
 

--- a/InfServer/Game/Arena/ScriptArena.cs
+++ b/InfServer/Game/Arena/ScriptArena.cs
@@ -56,7 +56,7 @@ namespace InfServer.Game
             _startCfg = _server._zoneConfig.startGame;
 
             //Run initial hides if it doesn't depend on a game running
-            if (_startCfg.initialHides)
+            if (!_startCfg.initialHides)
                 initialHideSpawns();
         }
 


### PR DESCRIPTION
* Run initial hides on Arena creation when `[startgame] initialhides` is false
* Updates max player distance check, use `99999` as the minimum value for the max value to be effective