### PR TITLE
Support for nested files itm veh

### DIFF
--- a/Assets/Itm/ItmInfo.Item.cs
+++ b/Assets/Itm/ItmInfo.Item.cs
@@ -108,6 +108,11 @@ namespace Assets
 			range = 0;
 			return false;
 		}
+
+        public virtual List<string> getFilesToLoad()
+        { 
+            return FilesToLoad; 
+        }
     }
 }
 

--- a/Assets/Itm/ItmInfo.NestedItem.cs
+++ b/Assets/Itm/ItmInfo.NestedItem.cs
@@ -15,8 +15,8 @@ namespace Assets
                 item.id = CSVReader.GetInt(values[0]);
                 item.version = CSVReader.GetInt(values[1].Trim('v'));
                 item.itemID = CSVReader.GetInt(values[2]);
-                item.name = CSVReader.GetString(values[3]);
-                item.location = CSVReader.GetString(values[4]);
+                item.name = CSVReader.GetQuotedString(values[3]);
+                item.location = CSVReader.GetQuotedString(values[4]);
                 return item;
             }
         }

--- a/Assets/Itm/ItmInfo.cs
+++ b/Assets/Itm/ItmInfo.cs
@@ -111,6 +111,7 @@ namespace Assets
                         break;
                     case "18":
                         NestedItem nested = NestedItem.Load(values);
+                        nested.itemType = ItemType.Nested;
                         FilesToLoad.Add(nested.location);
                         itemInfo.Add(nested);
                         break;

--- a/Assets/Shared/CsvFile.cs
+++ b/Assets/Shared/CsvFile.cs
@@ -55,6 +55,10 @@ namespace Assets
                         {
                             i = end + 1;
                         }
+                        else
+                        {
+                            i = input.Length;
+                        }
                     }
                     else
                     {

--- a/Assets/Veh/VehInfo.Nested.cs
+++ b/Assets/Veh/VehInfo.Nested.cs
@@ -7,9 +7,7 @@
         /// </summary>
         public sealed class Nested : VehInfo
         {
-            /*public int Unknown434;
-            public string Unknown3D4;*/
-            public string Unknown5C8;
+            public string VehicleFileName;
 
             public Nested()
             {
@@ -18,11 +16,10 @@
 
             public override void Parse(ICsvParser parser)
             {
-                base.Parse(parser);
                 this.Version = int.Parse(parser.GetString().Substring(1)); // sets version...?
                 this.Id = parser.GetInt();
                 this.Name = parser.GetString();
-                this.Unknown5C8 = parser.GetString();
+                this.VehicleFileName = parser.GetString();
             }
         }
     }

--- a/InfServer/Game/Assets/AssetManager.cs
+++ b/InfServer/Game/Assets/AssetManager.cs
@@ -487,8 +487,8 @@ namespace InfServer.Game
 		}
 
         /// <summary>
-		/// Some vehicle files have nested vehicle files within, this will grab all of them as needed
-		/// </summary>	
+        /// Some vehicle files have nested vehicle files within, this will grab all of them as needed
+        /// </summary>	
         private VehicleFile LoadVehicleFiles(CfgInfo zoneConf) 
         {
             VehicleFile mainFile = AssetFileFactory.CreateFromFile<VehicleFile>(zoneConf.level.vehFile);
@@ -527,8 +527,8 @@ namespace InfServer.Game
         }
 
         /// <summary>
-		/// Some item files have nested item files within, this will grab all of them as needed
-		/// </summary>	
+        /// Some item files have nested item files within, this will grab all of them as needed
+        /// </summary>	
         private ItemFile LoadItemFiles(CfgInfo zoneConf) 
         {
             ItemFile mainFile = AssetFileFactory.CreateFromFile<ItemFile>(zoneConf.level.itmFile);


### PR DESCRIPTION
Fixes issues where some zones have .veh or .itm game files that have "nested" files hidden inside of them. There was already some support for this feature, but needed a little extra shove to get the nested files checked in as assets. This comes with a mandatory "out of memory" fix, or some of the files containing nested files will parse badly and run into an infinite loop issue until memory becomes an issue. I've tested to make sure this works in several already working zones, and I've tested and verified it worked on 3 out of 4 of the outofmemory(nested itm & veh zones: chaos4, CRPL, duel). Hauntedchaos has nested files that loads into the server without a hitch, but still has issues with launching locally (silent fail). If this PR gets out anytime soon, someone (if I don't remember to do it) will need to verify the mentioned zones work in Zone-Assets\Incompatible Zone Archives\OutOfMemory\ and then we can move those to the completed folder afterwards.