### PR TITLE
Bot behaviour and pathfinding update

### DIFF
--- a/dotnetcore/Server/Game/Arena/Bot/Bot.cs
+++ b/dotnetcore/Server/Game/Arena/Bot/Bot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿ using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -248,12 +248,9 @@ namespace InfServer.Bots
             {
                 Log.write(TLog.Warning, "Encountered excessive bot delta of {0}", delta);
 
-                _movement.freezeMovement(10);
+                _movement.freezeMovement(100);
                 _movement.stop();
-                _movement.updateState(0);
-
-                _tickLastUpdate = tickCount;
-
+                
                 return false;
             }
 

--- a/dotnetcore/Server/Game/Arena/Bot/Pathfinding/Pathfinder2.cs
+++ b/dotnetcore/Server/Game/Arena/Bot/Pathfinding/Pathfinder2.cs
@@ -52,7 +52,7 @@ namespace InfServer.Bots
             }
 
             rawGrid = new StaticGrid(lvlInfo.Width, lvlInfo.Height, clearances);
-            rawJpParam = new JumpPointParam(rawGrid, EndNodeUnWalkableTreatment.ALLOW, DiagonalMovement.Always);
+            rawJpParam = new JumpPointParam(rawGrid, EndNodeUnWalkableTreatment.DISALLOW, DiagonalMovement.Always);
 
             // Give a 2-tile "clearance" around blocked tiles for larger vehicles.
 
@@ -79,7 +79,7 @@ namespace InfServer.Bots
             }
 
             clearanceGrid = new StaticGrid(lvlInfo.Width, lvlInfo.Height, clearances);
-            clearanceJpParam = new JumpPointParam(clearanceGrid, EndNodeUnWalkableTreatment.ALLOW, DiagonalMovement.Always);
+            clearanceJpParam = new JumpPointParam(clearanceGrid, EndNodeUnWalkableTreatment.DISALLOW, DiagonalMovement.Always);
         }
 
         /// <summary>
@@ -146,7 +146,7 @@ namespace InfServer.Bots
                 //Add to logcounter
                 logcounter++;
 
-                //write single log for combined count of 50
+                //write single log for combined count of 20
                 if (logcounter == 20)
                 {
                     Log.write(TLog.Warning, "Excessive pathing queue count: " + pathingQueue.Count);


### PR DESCRIPTION
Update to pathfinding, preventing diagonal walking over physics. Clean up of bot behaviour when it does get stuck.