### PR TITLE
Make Y scale configurable in computeLeadFireAngle.

### DIFF
--- a/dotnetcore/ZoneServer/Game/ZoneServer.cs
+++ b/dotnetcore/ZoneServer/Game/ZoneServer.cs
@@ -191,6 +191,9 @@ namespace InfServer.Game
 
             _zoneConfig = CfgInfo.Load(cfgFilePath);
 
+            //Set the global Y scale: isometric levels use 0.7, non-isometric use 1.0
+            Helpers.ZoneLevelYScale = _zoneConfig.level.isometric ? 0.7d : 1.0d;
+
             //Load assets from zone config and populate AssMan
             try
             {

--- a/dotnetcore/ZoneServer/Protocol/Helpers/Math.cs
+++ b/dotnetcore/ZoneServer/Protocol/Helpers/Math.cs
@@ -14,6 +14,16 @@ namespace InfServer.Protocol
 	/// </summary>
 	public partial class Helpers
 	{	///////////////////////////////////////////////////
+		// Member Variables
+		//////////////////////////////////////////////////
+		/// <summary>
+		/// Global Y-scale used for lead-fire angle calculations.
+		/// Defaults to 0.7; set to 1.0 for non-isometric levels once
+		/// the zone config has been loaded.
+		/// </summary>
+		static public double ZoneLevelYScale = 0.7d;
+
+		///////////////////////////////////////////////////
 		// Member Functions
 		//////////////////////////////////////////////////
 		/// <summary>
@@ -201,7 +211,7 @@ namespace InfServer.Protocol
 
 			//Get the relative position of target at (x_1, x_2) where turret is at 0,0
 			double x_1 = target.positionX - state.positionX;
-			double x_2 = (target.positionY - state.positionY) / 0.7d;		//The Y coordinates are smaller than x, hence 0.7
+			double x_2 = (target.positionY - state.positionY) / ZoneLevelYScale;		//The Y coordinates are smaller than x, hence 0.7
 
 			// Convert velocity (thousandths of pixels per tick) to pixels per tick
 			double v_1 = target.velocityX / 1000.0d;


### PR DESCRIPTION
This is necessary for CR Zones with computer turrets, for example Rogue Trader.

Setting a public static variable that gets updated during the zone config parsing seemed like the lowest-impact implementation possible. `computeLeadFireAngle` is used in many places in the project where the isometric/non-isometric zone config is not available.