### PR TITLE
Fix computer aiming to not allow for angle length 0

### DIFF
--- a/dotnetcore/ZoneServer/Game/Objects/Vehicle.Computer.cs
+++ b/dotnetcore/ZoneServer/Game/Objects/Vehicle.Computer.cs
@@ -289,8 +289,8 @@ namespace InfServer.Game
                 if ((short)pAngle < _type.AngleStart)
                     return false;
 
-            if (_type.AngleLength < 360)
-                if ((short)pAngle > _type.AngleLength)
+            if (_type.AngleLength > 0 && _type.AngleLength < 360)
+                if ((short)pAngle > _type.AngleStart + _type.AngleLength)
                     return false;
 
             //Check if player is within turrets vision


### PR DESCRIPTION
This issue was documented here https://gist.github.com/fowlmouth/58a917b0d1a10978ff5796d9aa85a2bc
This fix is necessary for most of the turrets in CR, specifically to fix for RT