### PR TITLE
Fix max player distance distance in arena lio for item hide to be 99999

### DIFF
--- a/dotnetcore/ZoneServer/Game/Arena/ArenaLio.cs
+++ b/dotnetcore/ZoneServer/Game/Arena/ArenaLio.cs
@@ -598,7 +598,7 @@ namespace InfServer.Game
                 if (hs.Hide.HideData.MinPlayerDistance != 0 &&
                     getPlayersInRange(sp.posX, sp.posY, hs.Hide.HideData.MinPlayerDistance, true).Count > 0)
                     continue;
-                if (hs.Hide.HideData.MaxPlayerDistance < Int32.MaxValue &&
+                if (hs.Hide.HideData.MaxPlayerDistance < 99999 &&
                     getPlayersInRange(sp.posX, sp.posY, hs.Hide.HideData.MaxPlayerDistance, true).Count == 0)
                     continue;
 


### PR DESCRIPTION
…99, consistent with Vehicle hides