### PR TITLE
Refactor held category checks into Player.heldCategoryCheck

### DIFF
--- a/dotnetcore/ZoneServer/Game/Commands/Chat/Commands.cs
+++ b/dotnetcore/ZoneServer/Game/Commands/Chat/Commands.cs
@@ -293,40 +293,15 @@ namespace InfServer.Game.Commands.Chat
                         }
                     }
 
-                    //Held category checks (mirrored in Player#inventoryModify)
-                    if (ii == null && item.heldCategoryType > 0)
+                    //Held category checks (delegates to Player#heldCategoryCheck)
+                    int categoryAllowed = player.heldCategoryCheck(item, buyAmount);
+                    if (categoryAllowed <= 0)
                     {
-                        int alreadyHolding = player._inventory
-                            .Where(it => it.Value.item.heldCategoryType == item.heldCategoryType)
-                            .Sum(it => 1);
-                        //Veh editor says a held category is "maximum number of unique types of items of this category type"
-                        //Vehicle hold categories take precedence over the cfg values
-                        if (player.ActiveVehicle._type.HoldItemLimits[item.heldCategoryType] != -1)
-                        {
-                            if (1 + alreadyHolding > player.ActiveVehicle._type.HoldItemLimits[item.heldCategoryType])
-                            {
-                                player.sendMessage(-1, "You are already carrying the maximum amount of items in this category.");
-                                continue;
-                            }
-                        }
-                        else if (player.ActiveVehicle != player._baseVehicle &&
-                            player._baseVehicle._type.HoldItemLimits[item.heldCategoryType] != -1)
-                        {
-                            if (1 + alreadyHolding > player._baseVehicle._type.HoldItemLimits[item.heldCategoryType])
-                            {
-                                player.sendMessage(-1, "You are already carrying the maximum amount of items in this category.");
-                                continue;
-                            }
-                        }
-                        else if (player._server._zoneConfig.heldCategory.limit[item.heldCategoryType] != -1)
-                        {
-                            if (1 + alreadyHolding > player._server._zoneConfig.heldCategory.limit[item.heldCategoryType])
-                            {
-                                player.sendMessage(-1, "You are already carrying the maximum amount of items in this category.");
-                                continue;
-                            }
-                        }
+                        player.sendMessage(-1, "You are already carrying the maximum amount of items in this category.");
+                        continue;
                     }
+                    if (categoryAllowed < buyAmount)
+                        buyAmount = categoryAllowed;
 
                     //Make sure he has enough cash first..
                     int buyPrice = item.buyPrice * buyAmount;

--- a/dotnetcore/ZoneServer/Game/Commands/Mod/Basic.cs
+++ b/dotnetcore/ZoneServer/Game/Commands/Mod/Basic.cs
@@ -1277,8 +1277,16 @@ namespace InfServer.Game.Commands.Mod
                 player._arena.itemSpawn(item, (ushort)quantity, player._state.positionX, player._state.positionY, player);
             }
             else
-            {	//Modify the recipient inventory
-                recipient.inventoryModify(item, quantity);
+            {	//Modify the recipient inventory, respecting held category limits
+                int allowed = recipient.heldCategoryCheck(item, quantity);
+                if (allowed <= 0)
+                {
+                    player.sendMessage(-1, string.Format("{0} is already carrying the maximum amount of items in this category.", recipient._alias));
+                    return;
+                }
+                if (allowed < quantity)
+                    player.sendMessage(-1, string.Format("Held category limit reduced prize from {0} to {1} {2}.", quantity, allowed, item.name));
+                recipient.inventoryModify(item, allowed);
             }
         }
 


### PR DESCRIPTION
Replace duplicated inline held-category logic in ?buy with a call to the shared Player.heldCategoryCheck helper, which also clamps the requested quantity to the allowed amount. Apply the same limit to the mod ?prize command so granted items respect category caps.